### PR TITLE
Add documentation

### DIFF
--- a/kubernetes/Makefile
+++ b/kubernetes/Makefile
@@ -14,11 +14,13 @@ configure: ## Configure minikube and external services
 
 helm: ## Setup Helm client, server and repositories
 	@helm init
+	@helm repo add ryr https://request-yo-racks.github.io/charts/
+	@helm repo update
 
 minikube: # Setup minikube, REX ConfigMap, and ECR access.
 	@$(MAKE) -C provision/minikube minikube-start
 
-provision: minikube ## Provision the minikube cluster
+provision: minikube helm ## Provision the minikube cluster
 
 unprovision: ## Unprovision the minikube cluster
 	$(MAKE) -C provision/minikube minikube-delete

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,7 +1,29 @@
 # Kubernetes infra
 
-## Create secrets
+## Pre-requisite
+
+### Create secrets
 
 ```
-kubectl create secret generic ryr-api-secrets --from-file=~/.config/ryr/kubernetes-secrets
+kubectl create secret generic ryr-api-secrets --from-file="${HOME}/.config/ryr/kubernetes-secrets"
+```
+
+## Setup
+
+### Provisioning and configuring the local environment
+
+```bash
+git clone git@github.com:request-yo-racks/infra.git
+cd infra/kubernetes
+make provision configure
+```
+
+!!! Note
+    The external services are not exposed outside of the cluster. If you need to access them for any reason, destroy them and redeploy them using `NodePort` as the service type.
+
+###
+
+```bash
+eval $(minikube docker-env)
+make docker-build deploy-minikube
 ```

--- a/kubernetes/configure/configure-secrets.sh
+++ b/kubernetes/configure/configure-secrets.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -euo pipefail
 
-kubectl create secret generic ryr-api-secrets --from-file=~/.config/ryr/kubernetes-secrets
+kubectl create secret generic ryr-api-secrets --from-file="${HOME}/.config/ryr/kubernetes-secrets"

--- a/kubernetes/provision/minikube/minikube-setup.sh
+++ b/kubernetes/provision/minikube/minikube-setup.sh
@@ -39,9 +39,6 @@ until minikube dashboard >/dev/null 2>&1; do
 done
 echo
 
-# Initialize Helm on both client and server.
-helm init
-
 # Display a message to tell to update the environment variables.
 minikube docker-env
 


### PR DESCRIPTION
Adds documentation to explain how to use the tools in this repo.

Drive-bys:
* Fix Helm initialization
  * Add the `ryr` chart repository and update it
* Fix the secret creation
  * `kubectl` does not expand `~` to be the home directory