### PR TITLE
Install Helm right after minikube

### DIFF
--- a/kubernetes/Makefile
+++ b/kubernetes/Makefile
@@ -13,7 +13,6 @@ configure: ## Configure minikube and external services
 	@cd configure/external-services && bash configure-external-services.sh
 
 helm: ## Setup Helm client, server and repositories
-	@helm init
 	@helm repo add ryr https://request-yo-racks.github.io/charts/
 	@helm repo update
 

--- a/kubernetes/provision/minikube/minikube-setup.sh
+++ b/kubernetes/provision/minikube/minikube-setup.sh
@@ -31,13 +31,8 @@ fi
 echo -e "${C_GREEN}Configuring minikube context...${C_RESET_ALL}"
 kubectl config use-context minikube
 
-# Start the dashboard.
-echo -e -n "${C_GREEN}The dashboard will be displayed in a new tab in the default browser...${C_RESET_ALL}"
-until minikube dashboard >/dev/null 2>&1; do
-  echo -e -n "${C_GREEN}.${C_RESET_ALL}"
-  sleep 1
-done
-echo
+# Set up Helm.
+helm init
 
 # Display a message to tell to update the environment variables.
 minikube docker-env
@@ -45,3 +40,11 @@ minikube docker-env
 # Enable addons
 minikube addons enable heapster
 minikube addons enable ingress
+
+# Start the dashboard.
+echo -e -n "${C_GREEN}The dashboard will be displayed in a new tab in the default browser...${C_RESET_ALL}"
+until minikube dashboard >/dev/null 2>&1; do
+  echo -e -n "${C_GREEN}.${C_RESET_ALL}"
+  sleep 1
+done
+echo


### PR DESCRIPTION
This changes the order of the operations in order to give time to all
the system pods to get cerated by the end of the provisioning phase.