### PR TITLE
Make bootstrap-osx script standalone again.

### DIFF
--- a/bootstrap/bootstrap-osx.sh
+++ b/bootstrap/bootstrap-osx.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
-# Import OSX common functions.
-source bootstrap-osx-common.sh
+# This script needs to be standalone to be run like this:
+# bash <(curl -fsSL https://raw.githubusercontent.com/request-yo-racks/infra/master/bootstrap/bootstrap-osx.sh)
+# Therefore cannot import other scripts.
 
 : ${BS_SILENT:=1}
 if [ "${BS_SILENT}" -eq "1" ]; then
@@ -10,10 +11,10 @@ if [ "${BS_SILENT}" -eq "1" ]; then
 fi
 
 # Install brew if needed.
-brew_install
+brew --version || /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
 # Update brew.
-brew_update
+brew update
 
 # Install brew formulas.
 brew install \


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

Description
-----------
<!-- Describe your changes in detail -->
Update the `bootstrap-osx script` to make it standalone again and
"pipeable" to bash.


Motivation and Context
----------------------
<!-- Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here. -->
Onbard users quickly.

How Has This Been Tested?
-------------------------
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran
to see how your change affects other areas of the code, etc. -->
Manually on my laptop.

Types of changes
----------------
<!-- What types of changes does your code introduce?
Select the choices apply: -->

- Bug fix (non-breaking change which fixes an issue)

Checklist:
----------
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. If you're unsure about any of these, don't hesitate to
ask. We're here to help! -->

-  [] I have updated the documentation accordingly.
-  [] I have written unit tests

<!-- Place the *FULL* URL of the issue here it this PR fixes an existing issue. -->
Fixes request-yo-racks/infra#24