### PR TITLE
Deploy RabbitMQ

### DIFF
--- a/kubernetes/configure/external-services/configure-external-services.sh
+++ b/kubernetes/configure/external-services/configure-external-services.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 : ${HELM_EXTRA_OPTS:=""}
 
 # Configure the required services.
-SERVICES="postgresql:0.9.5 redis:3.0.1"
+SERVICES="postgresql:0.14.2 rabbitmq:1.1.6 redis:3.4.2"
 for svc in ${SERVICES}; do
 
   # Extract parts.

--- a/kubernetes/configure/external-services/rabbitmq/values.common.yaml
+++ b/kubernetes/configure/external-services/rabbitmq/values.common.yaml
@@ -1,0 +1,3 @@
+# image:
+#   repository: "rabbitmq"
+#   tag: "3.7.5-management-alpine"

--- a/kubernetes/configure/external-services/rabbitmq/values.minikube.yaml
+++ b/kubernetes/configure/external-services/rabbitmq/values.minikube.yaml
@@ -1,6 +1,9 @@
-image: "rabbitmq:3.6.14-management-alpine"
-rabbitmqUsername: guest
-rabbitmqPassword: guest
+rabbitmq:
+  username: guest
+  password: guest
 persistence:
   enabled: false
-serviceType: NodePort
+serviceType: ClusterIP
+ingress:
+  enabled: true
+  hostName: rabbitmq.192.168.99.100.nip.io


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

New feature
===========

Description
-----------
<!--
Describe your changes in detail.
Add a screenshot if applicable.
-->
Adds the RabbitMQ service to the developer environment. This service
is required to work with Celery tasks.

Due to https://github.com/kubernetes/charts/issues/5479, the service is
currently configured to run as "ClusterIP" with an ingress controler.
While this works inside of a Kubernetes cluster, it does not work for
local development.

As a result, Redis will be temporarily used as a broker. Once The
issue #5479 will be resolved, RabbitMQ will become the broker.


Motivation and Context
----------------------
<!-- Why is this change required? What problem does it solve? -->
Use RabbitMQ as a broker for Celery.


How Has This Been Tested?
-------------------------
<!--
Add any information that could help the reviewer to validate the PR.
Please describe in detail how you tested your changes, include details
of your testing environment, and the tests you ran to see how your
change affects other areas of the code, etc.
-->
Deployed in a developer environment.


Checklist:
----------
<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

-  [] I have updated the documentation accordingly
-  [] I have written unit tests

<!--
Place the URL of the issue here it this PR fixes an existing issue.
Use either the *FULL* URL (preferred) or the `Username/Repository#`
syntax.
-->
Fixes request-yo-racks/infra#50