### PR TITLE
Replace dashboard waiting condition

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,14 +20,12 @@ Add a screenshot if applicable.
 -->
 
 
-Motivation and Context
-----------------------
-<!-- Why is this change required? What problem does it solve? -->
+<!-- Motivation and Context
+Why is this change required? What problem does it solve? -->
 
 
-How Has This Been Tested?
--------------------------
 <!--
+How Has This Been Tested?
 Add any information that could help the reviewer to validate the PR.
 Please describe in detail how you tested your changes, include details
 of your testing environment, and the tests you ran to see how your

--- a/kubernetes/provision/minikube/minikube-setup.sh
+++ b/kubernetes/provision/minikube/minikube-setup.sh
@@ -56,9 +56,9 @@ minikube docker-env
 minikube addons enable heapster
 minikube addons enable ingress
 
-# Start the dashboard.
-echo -e -n "${C_GREEN}The dashboard will be displayed in a new tab in the default browser...${C_RESET_ALL}"
-until minikube dashboard >/dev/null 2>&1; do
+# Wait for the dashboard to be ready.
+echo -e -n "${C_GREEN}Waiting for the dashboard to be ready...${C_RESET_ALL}"
+until minikube service -n kube-system kubernetes-dashboard >/dev/null 2>&1; do
   echo -e -n "${C_GREEN}.${C_RESET_ALL}"
   sleep 1
 done


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above. -->

Types of changes
----------------
<!--
What types of changes does your code introduce?
Select all the choices that apply:
-->
- Bug fix (non-breaking change which fixes an issue)

Description
-----------
<!--
Describe your changes in detail.
Add a screenshot if applicable.
-->
Due to a security issue, the minikube dashboard is now only available on
demand and the `minikube dashboard` command does not exit anymore. This
command was used to detect when minikube was ready to accept other
deployments.

This patch replaces this command with anither one checking whether the
dashboard service is up and running.




<!-- Motivation and Context
Why is this change required? What problem does it solve? -->


<!--
How Has This Been Tested?
Add any information that could help the reviewer to validate the PR.
Please describe in detail how you tested your changes, include details
of your testing environment, and the tests you ran to see how your
change affects other areas of the code, etc.
-->


Checklist:
----------
<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

-  [] I have updated the documentation accordingly
-  [] I have written unit tests

<!--
Place the URL of the issue here it this PR fixes an existing issue.
Use either the *FULL* URL (preferred) or the `Username/Repository#`
syntax.
-->
Fixes request-yo-racks/infra#59